### PR TITLE
Add -cm flag for Cloud Manager mode

### DIFF
--- a/psst/psst.py
+++ b/psst/psst.py
@@ -12,7 +12,9 @@ class Config(object):
 pass_config = click.make_pass_decorator(Config, ensure=True)
 
 @click.group(no_args_is_help=True)
+# @click.pass_obj
 @pass_config
+
 def cli(config):
     """PeopleSoft Secrets Tool"""
     pass    
@@ -23,13 +25,17 @@ def secrets():
     pass
 
 @secrets.command()
-def generate():
+@click.option('-cm', '--cloud-manager', 
+              default=False, 
+              help="Set Cloud Manager Mode for password lengths", 
+              is_flag=True)
+def generate(cloud_manager):
     """Generate a dictionary of secrets"""
     dict = {}
 
-    dict["access_pwd"] = psst.secrets.access_pwd.generate()
+    dict["access_pwd"] = psst.secrets.access_pwd.generate(cloud_manager)
     dict["db_connect_pwd"] = psst.secrets.db_connect_pwd.generate()
-    dict["db_user_pwd"] = psst.secrets.db_user_pwd.generate()
+    dict["db_user_pwd"] = psst.secrets.db_user_pwd.generate(cloud_manager)
     dict["domain_conn_pwd"] = psst.secrets.domain_conn_pwd.generate()
     dict["pia_gateway_admin_pwd"] = psst.secrets.pia_gateway_admin_pwd.generate()
     dict["pia_webprofile_user_pwd"] = psst.secrets.pia_webprofile_user_pwd.generate()

--- a/psst/psst.py
+++ b/psst/psst.py
@@ -12,7 +12,6 @@ class Config(object):
 pass_config = click.make_pass_decorator(Config, ensure=True)
 
 @click.group(no_args_is_help=True)
-# @click.pass_obj
 @pass_config
 
 def cli(config):

--- a/psst/secrets/access_pwd.py
+++ b/psst/secrets/access_pwd.py
@@ -2,12 +2,12 @@ import random
 import array
 
 # Database Access ID password. 
-# No more than 8 characters in length. 
+# No more than 8 characters in length for Cloud Manager
+# 25 characters default
 # The first character must be a letter
 # Remaining 7 characters may be a mixture of letters and numbers."
 
 MIN_LEN = 8
-MAX_LEN = 8
 
 DIGITS = ['0', '1', '2', '3', '4', '5', '6', '7', '8', '9']
 LOCASE_CHARACTERS = ['a', 'b', 'c', 'd', 'e', 'f', 'g', 'h',
@@ -23,7 +23,12 @@ UPCASE_CHARACTERS = ['A', 'B', 'C', 'D', 'E', 'F', 'G', 'H',
 COMBINED_LIST = DIGITS + UPCASE_CHARACTERS + LOCASE_CHARACTERS
 LETTERS_LIST = UPCASE_CHARACTERS + LOCASE_CHARACTERS
 
-def generate():
+def generate(cloud_manager):
+	if cloud_manager:
+		MAX_LEN = 8
+	else:
+		MAX_LEN = 25
+		
 	# randomly select at least one character from each character set above
 	rand_digit = random.choice(DIGITS)
 	rand_upper = random.choice(UPCASE_CHARACTERS)

--- a/psst/secrets/db_user_pwd.py
+++ b/psst/secrets/db_user_pwd.py
@@ -3,10 +3,10 @@ import array
 
 # Domain boot user (CLADM/PS/VP1) password. 
 # Only alphanumeric characters .
-# 8 characters in length.
+# 8 characters in length for Cloud Manager
+# 25 characters default
 
 MIN_LEN = 8
-MAX_LEN = 8
 
 DIGITS = ['0', '1', '2', '3', '4', '5', '6', '7', '8', '9']
 LOCASE_CHARACTERS = ['a', 'b', 'c', 'd', 'e', 'f', 'g', 'h',
@@ -21,7 +21,12 @@ UPCASE_CHARACTERS = ['A', 'B', 'C', 'D', 'E', 'F', 'G', 'H',
 
 COMBINED_LIST = DIGITS + UPCASE_CHARACTERS + LOCASE_CHARACTERS
 
-def generate():
+def generate(cloud_manager):
+	if cloud_manager:
+		MAX_LEN = 8
+	else:
+		MAX_LEN = 25
+
 	# randomly select at least one character from each character set above
 	rand_digit = random.choice(DIGITS)
 	rand_upper = random.choice(UPCASE_CHARACTERS)

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ README = (HERE / "README.md").read_text()
 
 setup_args = dict(
     name='psst',
-    version='0.0.1',
+    version='0.0.2',
     description='psst',
     long_description_content_type="text/markdown",
     long_description=README,


### PR DESCRIPTION
Passing `-cm` will create 8 character passwords for Access ID and DB Operator ID.

Fixes #9 