### PR TITLE
Add ES users, reorder output, expand -cm mode

### DIFF
--- a/psst/psst.py
+++ b/psst/psst.py
@@ -31,14 +31,20 @@ def generate(cloud_manager):
     """Generate a dictionary of secrets"""
     dict = {}
 
-    dict["access_pwd"] = psst.secrets.access_pwd.generate(cloud_manager)
-    dict["db_connect_pwd"] = psst.secrets.db_connect_pwd.generate()
     dict["db_user_pwd"] = psst.secrets.db_user_pwd.generate(cloud_manager)
-    dict["domain_conn_pwd"] = psst.secrets.domain_conn_pwd.generate()
+    dict["access_pwd"] = psst.secrets.access_pwd.generate(cloud_manager)
+    dict["es_admin_pwd"] = psst.secrets.es_admin_pwd.generate()
+    dict["es_proxy_pwd"] = psst.secrets.es_proxy_pwd.generate()
+    dict["wls_admin_user_pwd"] = psst.secrets.wls_admin_user_pwd.generate()
+    if cloud_manager:
+        dict["db_admin_pwd"] = psst.secrets.db_admin_pwd.generate()
+    dict["db_connect_pwd"] = psst.secrets.db_connect_pwd.generate()
     dict["pia_gateway_admin_pwd"] = psst.secrets.pia_gateway_admin_pwd.generate()
     dict["pia_webprofile_user_pwd"] = psst.secrets.pia_webprofile_user_pwd.generate()
+    dict["domain_conn_pwd"] = psst.secrets.domain_conn_pwd.generate()
     dict["pskey_password"] = psst.secrets.pskey_password.generate()
-    dict["wls_admin_user_pwd"] = psst.secrets.wls_admin_user_pwd.generate()
+    if cloud_manager:
+        dict["windows_password"] = psst.secrets.windows_pwd.generate()
 
     click.echo(json.dumps(dict, indent=4))
 
@@ -62,13 +68,19 @@ def generate(type, name, compartment_id, cloud_manager):
         ocicfg = psst.vault.oci.config()
         # TODO - generate dict
         dict = {}
-        dict["access_pwd"] = psst.secrets.access_pwd.generate(cloud_manager)
-        dict["db_connect_pwd"] = psst.secrets.db_connect_pwd.generate()
         dict["db_user_pwd"] = psst.secrets.db_user_pwd.generate(cloud_manager)
-        dict["domain_conn_pwd"] = psst.secrets.domain_conn_pwd.generate()
+        dict["access_pwd"] = psst.secrets.access_pwd.generate(cloud_manager)
+        dict["es_admin_pwd"] = psst.secrets.es_admin_pwd.generate()
+        dict["es_proxy_pwd"] = psst.secrets.es_proxy_pwd.generate()
+        dict["wls_admin_user_pwd"] = psst.secrets.wls_admin_user_pwd.generate()
+        if cloud_manager:
+            dict["db_admin_pwd"] = psst.secrets.db_admin_pwd.generate()
+        dict["db_connect_pwd"] = psst.secrets.db_connect_pwd.generate()()
         dict["pia_gateway_admin_pwd"] = psst.secrets.pia_gateway_admin_pwd.generate()
         dict["pia_webprofile_user_pwd"] = psst.secrets.pia_webprofile_user_pwd.generate()
+        dict["domain_conn_pwd"] = psst.secrets.domain_conn_pwd.generate
         dict["pskey_password"] = psst.secrets.pskey_password.generate()
-        dict["wls_admin_user_pwd"] = psst.secrets.wls_admin_user_pwd.generate()
+        if cloud_manager:
+            dict["windows_password"] = psst.secrets.windows_pwd.generate()
               
-        vault = psst.vault.oci.create(ocicfg, name, compartment_id, dict)            
+        vault = psst.vault.oci.create(ocicfg, name, compartment_id, dict)

--- a/psst/secrets/__init__.py
+++ b/psst/secrets/__init__.py
@@ -8,3 +8,6 @@ from .domain_conn_pwd import generate
 from .wls_admin_user_pwd import generate
 from .pia_gateway_admin_pwd import generate
 from .pia_webprofile_user_pwd import generate
+from .es_admin_pwd import generate
+from .es_proxy_pwd import generate
+from .windows_pwd import generate

--- a/psst/secrets/es_admin_pwd.py
+++ b/psst/secrets/es_admin_pwd.py
@@ -1,0 +1,44 @@
+import random
+import array
+
+# Elasticsearch Admin User Password (esadmin)
+# Between 8 and 30 characters in length.
+# Only alphanumeric characters.
+
+MIN_LEN = 8
+MAX_LEN = 30
+
+DIGITS = ['0', '1', '2', '3', '4', '5', '6', '7', '8', '9']
+LOCASE_CHARACTERS = ['a', 'b', 'c', 'd', 'e', 'f', 'g', 'h',
+					'i', 'j', 'k', 'm', 'n', 'o', 'p', 'q',
+					'r', 's', 't', 'u', 'v', 'w', 'x', 'y',
+					'z']
+
+UPCASE_CHARACTERS = ['A', 'B', 'C', 'D', 'E', 'F', 'G', 'H',
+					'I', 'J', 'K', 'M', 'N', 'O', 'P', 'Q',
+					'R', 'S', 'T', 'U', 'V', 'W', 'X', 'Y',
+					'Z']
+
+COMBINED_LIST = DIGITS + UPCASE_CHARACTERS + LOCASE_CHARACTERS
+
+def generate():
+	# randomly select at least one character from each character set above
+	rand_digit = random.choice(DIGITS)
+	rand_upper = random.choice(UPCASE_CHARACTERS)
+	rand_lower = random.choice(LOCASE_CHARACTERS)
+
+	temp_pass = rand_digit + rand_upper + rand_lower
+
+
+	# fill the rest by selecting randomly from the combined list
+	for x in range(MAX_LEN - 3):
+		temp_pass = temp_pass + random.choice(COMBINED_LIST)
+		
+		temp_pass_list = array.array('u', temp_pass)
+		random.shuffle(temp_pass_list)
+
+	password = ""
+	for x in temp_pass_list:
+			password = password + x
+	
+	return password

--- a/psst/secrets/es_proxy_pwd.py
+++ b/psst/secrets/es_proxy_pwd.py
@@ -1,0 +1,44 @@
+import random
+import array
+
+# Elasticsearch Proxy User Password (people)
+# Between 8 and 30 characters in length.
+# Only alphanumeric characters.
+
+MIN_LEN = 8
+MAX_LEN = 30
+
+DIGITS = ['0', '1', '2', '3', '4', '5', '6', '7', '8', '9']
+LOCASE_CHARACTERS = ['a', 'b', 'c', 'd', 'e', 'f', 'g', 'h',
+					'i', 'j', 'k', 'm', 'n', 'o', 'p', 'q',
+					'r', 's', 't', 'u', 'v', 'w', 'x', 'y',
+					'z']
+
+UPCASE_CHARACTERS = ['A', 'B', 'C', 'D', 'E', 'F', 'G', 'H',
+					'I', 'J', 'K', 'M', 'N', 'O', 'P', 'Q',
+					'R', 'S', 'T', 'U', 'V', 'W', 'X', 'Y',
+					'Z']
+
+COMBINED_LIST = DIGITS + UPCASE_CHARACTERS + LOCASE_CHARACTERS
+
+def generate():
+	# randomly select at least one character from each character set above
+	rand_digit = random.choice(DIGITS)
+	rand_upper = random.choice(UPCASE_CHARACTERS)
+	rand_lower = random.choice(LOCASE_CHARACTERS)
+
+	temp_pass = rand_digit + rand_upper + rand_lower
+
+
+	# fill the rest by selecting randomly from the combined list
+	for x in range(MAX_LEN - 3):
+		temp_pass = temp_pass + random.choice(COMBINED_LIST)
+		
+		temp_pass_list = array.array('u', temp_pass)
+		random.shuffle(temp_pass_list)
+
+	password = ""
+	for x in temp_pass_list:
+			password = password + x
+	
+	return password

--- a/psst/secrets/windows_pwd.py
+++ b/psst/secrets/windows_pwd.py
@@ -1,0 +1,50 @@
+import random
+import array
+
+# Windows User Password (opc)
+# Between 8 and 30 characters in length. 
+# 1 lowercase letter
+# 1 uppercase letter
+# 1 number
+# 1 special character
+
+MIN_LEN = 8
+MAX_LEN = 30
+
+DIGITS = ['0', '1', '2', '3', '4', '5', '6', '7', '8', '9']
+LOCASE_CHARACTERS = ['a', 'b', 'c', 'd', 'e', 'f', 'g', 'h',
+					'i', 'j', 'k', 'm', 'n', 'o', 'p', 'q',
+					'r', 's', 't', 'u', 'v', 'w', 'x', 'y',
+					'z']
+
+UPCASE_CHARACTERS = ['A', 'B', 'C', 'D', 'E', 'F', 'G', 'H',
+					'I', 'J', 'K', 'M', 'N', 'O', 'P', 'Q',
+					'R', 'S', 'T', 'U', 'V', 'W', 'X', 'Y',
+					'Z']
+
+SYMBOLS = ['_', '-', '#', '!', '@', '$', '%', '^', '&', '*', '(', ')', '=', '+', '[', ']', '{', '}', ',', '.', '<', '>', '|']
+
+COMBINED_LIST = DIGITS + UPCASE_CHARACTERS + LOCASE_CHARACTERS + SYMBOLS
+
+def generate():
+	# randomly select at least one character from each character set above
+	rand_digit = random.choice(DIGITS)
+	rand_upper = random.choice(UPCASE_CHARACTERS)
+	rand_lower = random.choice(LOCASE_CHARACTERS)
+	rand_symbol = random.choice(SYMBOLS)
+
+	temp_pass = rand_digit + rand_upper + rand_lower + rand_symbol
+
+
+	# fill the rest by selecting randomly from the combined list
+	for x in range(MAX_LEN - 4):
+		temp_pass = temp_pass + random.choice(COMBINED_LIST)
+		
+		temp_pass_list = array.array('u', temp_pass)
+		random.shuffle(temp_pass_list)
+
+	password = ""
+	for x in temp_pass_list:
+			password = password + x
+	
+	return password


### PR DESCRIPTION
* Add Elasticsearch admin and proxy passwords
* Add Windows user password
* Add Database Admin (SYS/SYSTEM) password
* Reorder passwords to match Cloud Manager input order
* Display DB Admin and Windows passwords only when `-cm` switch is used