### PR TITLE
Add OCI Image mode for Marketplace Images

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ Usage: psst [OPTIONS] COMMAND [ARGS]...
 
 Options:
   --help  Show this message and exit.
+  
 
 Commands:
   secrets  Working with PeopleSoft Environment secrets
@@ -18,14 +19,38 @@ Commands:
 ```
 $ psst secrets generate
 {
-    "access_pwd": "WrKT6ap3",
-    "db_connect_pwd": "IVkCZNjUOKhaQdv8eB8aOQZ6ZP0jp5",
-    "db_user_pwd": "FPeX9qSu",
-    "domain_conn_pwd": "FD57pUkA1FddEIpMgGe",
-    "pia_gateway_admin_pwd": "nWJ04cGQygPiWnoknyPsPf4f1ajIUW",
-    "pia_webprofile_user_pwd": "T64BvQ9K3iwfvesjs0na30UDFoIFG0",
-    "pskey_password": "4Kt9nCgAGIDgR4wHTUqEZeh4z0hZEy",
-    "wls_admin_user_pwd": "ispTFU7ami!oGME@n^ARtKTv6K@Tf&"
+    "db_user_pwd": "WTM7Dx3ha9wpQbu1A60q7rhTP",
+    "access_pwd": "GuA2TyH0Hh62ZXvh9QeSC2dux",
+    "es_admin_pwd": "hEQ5dq7KfxcuSOqUBOazcp5ETvR3vs",
+    "es_proxy_pwd": "R2DWro330JmqyYkuN2WEvhJ50tzZVX",
+    "wls_admin_user_pwd": "v#%uNBJtA4D8$&yK#uzJ$RcqD!Vqiq",
+    "db_connect_pwd": "ir92R3mNTv1vAPe1cEYxtG8jI3YV5t",
+    "pia_gateway_admin_pwd": "EY8PkYawh4ZvB3O0VbHI3qqPZw3S5b",
+    "pia_webprofile_user_pwd": "x2i07XuWeWyj43Jbe4REJpBmEJYpU3",
+    "domain_conn_pwd": "WoVv1mWZ25cR93Mmc9m",
+    "pskey_password": "JNnPyqu7KF7es8ahGC13Si2BQDtN07"
+}
+```
+
+### Cloud Manager Mode
+
+Adding the `-cm` flag (`--cloud-manager`) will generate passwords that comply with the Cloud Manager password requirements. It will also generate a Windows user password.
+
+```
+psst secrets generate -cm
+{
+    "db_user_pwd": "do7iBVFD",
+    "access_pwd": "q6NtpH0w",
+    "es_admin_pwd": "KAQfp7zj5GNZ8M1PyBx7dpzcFq7EwG",
+    "es_proxy_pwd": "biS6eCOZNxkTDim7m5wpkEMu3JG3rd",
+    "wls_admin_user_pwd": "!Kk!$2Qt$p7X$UIrAO52yq1^r93&Mr",
+    "db_admin_pwd": "PVr7EJu5IxcdkU4k3U8a8_0eeVs1GN",
+    "db_connect_pwd": "9SgPuuygwSh2i0t8BStvh4o7HN2kqR",
+    "pia_gateway_admin_pwd": "FsIUb9ZmuQb9tOKXz0tZGov7F6bMyE",
+    "pia_webprofile_user_pwd": "c6cMrNipgKBwEMrp6teVYeb026H3Rp",
+    "domain_conn_pwd": "1tqEWEHfVnR4X5G01Nb",
+    "pskey_password": "3ObFEV6YVhDesde1A7EJupazHwdqy4",
+    "windows_password": "1I6vfbC0x--@M!UM>$&*XyM42!eo@Y"
 }
 ```
 


### PR DESCRIPTION
Marketplace OCI Image need a JSON string with passwords, but the key names are different. `-oci` will rename the keys so you can copy/paste the output into User Data.